### PR TITLE
Enable strict mode.

### DIFF
--- a/editors/ace/editbook_main.js
+++ b/editors/ace/editbook_main.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function EditBook_NewEditor(div, ws) {
     return {

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function EditBook_NewEditor(elem, ws) {
     document.body.style.margin = '0';
     var menu = new MonacoMenu(elem);

--- a/editors/plain/editbook_main.js
+++ b/editors/plain/editbook_main.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function EditBook_NewEditor(div, ws) {
     return {

--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,8 @@
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" />
 <script src="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <script type="text/javascript">
+'use strict';
+
 function EditBook_SaveFile(path, data, ondone) {
     $.post("/save/", {path: path, data:data})
      .done(ondone);
@@ -12,6 +14,8 @@ function EditBook_SaveFile(path, data, ondone) {
 </script>
 <script src="/editor/editbook_main.js"></script>
 <script type="text/javascript">
+'use strict';
+
 $(function() {
     openWs();
 });


### PR DESCRIPTION
- This enables ECMA262's [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).
- This does not have any regressions if there is no deprecated (legacy) features (e.g. `with` statement, `arguments.callee`, or `arguments.caller`).