### PR TITLE
Use absolute path for identifying a file.

### DIFF
--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -39,7 +39,9 @@ function EditBook_NewEditor(elem, ws) {
 
     return {
         init: ()=>{},
-        open: (path, data) => { menu.setPath(path); g_current.open(path, data);  }
+        open: (path, data, abspath) => {
+            menu.setPath(path); g_current.open(abspath, data);
+        }
     };
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -40,7 +40,7 @@ function openWs() {
         switch(event.data[0]) {
         case '0':
             var opcmd = JSON.parse(data);
-            openFile(opcmd.Path, opcmd.Data)
+            g_editor.open(opcmd.path, opcmd.data, opcmd.abspath);
             break;
         case '1':
             // pong
@@ -56,12 +56,6 @@ function openWs() {
 
 function onHeartBeat(ws) {
     ws.send("1");
-}
-
-
-function openFile(path, data) {
-    console.log("open called", path);
-    g_editor.open(path, data);
 }
 
 function onDisconnect() {


### PR DESCRIPTION
This cleans up some part of code handling files. This is
actually a part of code for language-server protocol, since
the protocol specifies the file location with absolute path.