### PR TITLE
Style fixes

### DIFF
--- a/editors/monaco/.eslintrc.yml
+++ b/editors/monaco/.eslintrc.yml
@@ -6,5 +6,8 @@ env:
 rules:
   # TODO: camelcase should be added after the refactoring.
   camelcase: off
+  # TODO: require-jsdoc should be added after the refactoring.
+  require-jsdoc: off
+  prefer-spread: off
   linebreak-style: off
   no-var: off

--- a/editors/monaco/.eslintrc.yml
+++ b/editors/monaco/.eslintrc.yml
@@ -4,8 +4,6 @@ env:
   es6: true
 
 rules:
-  # TODO: camelcase should be added after the refactoring.
-  camelcase: off
   # TODO: require-jsdoc should be added after the refactoring.
   require-jsdoc: off
   prefer-spread: off

--- a/editors/monaco/.eslintrc.yml
+++ b/editors/monaco/.eslintrc.yml
@@ -9,5 +9,6 @@ rules:
   # TODO: require-jsdoc should be added after the refactoring.
   require-jsdoc: off
   prefer-spread: off
+  prefer-rest-params: off
   linebreak-style: off
   no-var: off

--- a/editors/monaco/.eslintrc.yml
+++ b/editors/monaco/.eslintrc.yml
@@ -4,4 +4,7 @@ env:
   es6: true
 
 rules:
+  # TODO: camelcase should be added after the refactoring.
+  camelcase: off
   linebreak-style: off
+  no-var: off

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -3,7 +3,7 @@
 var g_current;
 var g_menu;
 
-function NotifyModifyStatusChanged() {
+function notifyModifyStatusChanged() {
     g_menu.setEnabled(g_current.dirty);
 }
 
@@ -38,8 +38,9 @@ function EditBook_NewEditor(elem, ws) {
     menu.unsplit_window = (main_div) => {
         if(g_current != main_editor) {
             // we want to detach sub_editor from div and re-attach to main_div.
-            // But I don't know how to do it. So just set model and path from sub_editor.
-            // This lost scroll position information, etc. May be just restore scroll position is better than now.
+            // But I don't know how to do it. So just set model and path
+            // from sub_editor. This lost scroll position information, etc.
+            // May be just restore scroll position is better than now.
 
             // var state = g_current.editor.saveViewState();
 
@@ -104,7 +105,7 @@ function initializeLanguageServices(ws, languageservice, callback) {
     ws.send('3');
 }
 
-function NotifyFocusChanged(editor) {
+function notifyFocusChanged(editor) {
     g_current = editor;
     g_menu.setPath(editor.path);
 }
@@ -116,16 +117,16 @@ function NotifyFocusChanged(editor) {
 function MonacoMenu(holder) {
     var builder = [];
     builder.push(
-'<button type="button" id="saveButton">Save</button> -- <input type="checkbox" id="split">split<br>',
+'<button type="button" id="saveButton">Save</button> ' +
+'-- <input type="checkbox" id="split">split<br>',
 'path: <span id="pathSpan"></span><br>',
-// '<div id="mainDiv" style="position:absolute;top:50;left:0;bottom:0;right:0">',
-'<div id="mainDiv" style="position:absolute;top:50;left:0;bottom:0;width:100%;overflow:hidden">',
-// 'This is the test area.',
+'<div id="mainDiv" ' +
+'style="position:absolute;top:50;left:0;bottom:0;width:100%;overflow:hidden">',
 '</div>'
     );
     holder.html(builder.join(''));
 
-    var main_div = document.getElementById('mainDiv'); // holder.find("#mainDiv");
+    var main_div = document.getElementById('mainDiv');
     this.main_div = main_div;
 
     var sub_div = document.createElement('div');
@@ -148,6 +149,7 @@ function MonacoMenu(holder) {
     }
 
     $('#split').change(function() {
+        // eslint-disable-next-line no-invalid-this
         if(this.checked) {
             // split
             holder.append(sub_div);
@@ -211,13 +213,14 @@ EditBookMonacoEditor.prototype.open = function(path, data) {
         this.dirty = false;
         this.savedVersionId = model.getAlternativeVersionId();
 
-        NotifyModifyStatusChanged();
+        notifyModifyStatusChanged();
         this.lservice = {onChange: (a, b)=>{}};
         model.onDidChangeContent((change) => {
             var prev_dirty = this.dirty;
-            this.dirty = this.savedVersionId !== model.getAlternativeVersionId();
+            this.dirty = (
+                this.savedVersionId !== model.getAlternativeVersionId());
             if(prev_dirty != this.dirty) {
-                NotifyModifyStatusChanged();
+                notifyModifyStatusChanged();
             }
 
             this.lservice.onChange(model, change);
@@ -256,10 +259,11 @@ EditBookMonacoEditor.prototype.save = function() {
         svc.willSave(model);
     }
     // TODO: should use willSaveWaitUntil?
+    // eslint-disable-next-line new-cap
     EditBook_SaveFile(this.path, model.getValue(), () => {
         this.savedVersionId = model.getAlternativeVersionId();
         this.dirty = false;
-        NotifyModifyStatusChanged();
+        notifyModifyStatusChanged();
 
         toastr.info('saved');
         if (svc) {
@@ -268,15 +272,12 @@ EditBookMonacoEditor.prototype.save = function() {
     });
 };
 
-EditBookMonacoEditor.initializeModule = function() {
-    var onInit = [];
-};
-
 EditBookMonacoEditor.prototype.init = function() {
     this.editor = monaco.editor.create(this.elem);
-    this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, ()=>this.save());
+    this.editor.addCommand(
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, ()=>this.save());
     this.editor.updateOptions({'theme': 'vs-dark'});
     this.editor.onDidFocusEditor(() => {
-        NotifyFocusChanged(this);
+        notifyFocusChanged(this);
     });
 };

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -59,7 +59,7 @@ EditBook.newEditor = function(elem, ws) {
             gCurrent.open(abspath, data);
         },
     };
-}
+};
 
 function initializeModule() {
     function onAmdEnabled() {

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -56,7 +56,7 @@ function EditBook_NewEditor(elem, ws) {
         open: (path, data, abspath) => {
             menu.setPath(path);
             g_current.open(abspath, data);
-        }
+        },
     };
 }
 
@@ -123,20 +123,20 @@ function MonacoMenu(holder) {
 // 'This is the test area.',
 '</div>'
     );
-    holder.html(builder.join(""));
+    holder.html(builder.join(''));
 
-    var main_div = document.getElementById("mainDiv"); // holder.find("#mainDiv");
+    var main_div = document.getElementById('mainDiv'); // holder.find("#mainDiv");
     this.main_div = main_div;
 
-    var sub_div = document.createElement("div");
-    sub_div.style.cssText = "position: absolute; top:0px; bottom:0px";
+    var sub_div = document.createElement('div');
+    sub_div.style.cssText = 'position: absolute; top:0px; bottom:0px';
     sub_div.style.overflow = 'hidden';
-    sub_div.id = "subDiv";
+    sub_div.id = 'subDiv';
     this.sub_div = sub_div;
 
     var menu = this;
 
-    $("#saveButton").click(function() {
+    $('#saveButton').click(function() {
         menu.save();
     }
     );
@@ -144,10 +144,10 @@ function MonacoMenu(holder) {
     function resize(elem, left, top, width) {
         elem.style.width = width;
         elem.style.top = top;
-        elem.style.left = left + "px";
+        elem.style.left = left + 'px';
     }
 
-    $("#split").change(function() {
+    $('#split').change(function() {
         if(this.checked) {
             // split
             holder.append(sub_div);
@@ -156,36 +156,34 @@ function MonacoMenu(holder) {
 
             var editorWidth = width / 2;
 
-            resize(main_div, 0, main_div.offsetTop, "50%");
-            resize(sub_div, editorWidth, main_div.offsetTop, "50%");
+            resize(main_div, 0, main_div.offsetTop, '50%');
+            resize(sub_div, editorWidth, main_div.offsetTop, '50%');
 
             menu.split_window(main_div, sub_div);
-
         } else {
             // unsplit
 
             var width = main_div.clientWidth;
 
             $(sub_div).remove();
-            resize(main_div, 0, main_div.top, "100%");
+            resize(main_div, 0, main_div.top, '100%');
 
             menu.unsplit_window(main_div);
         }
     });
-
 }
 
 MonacoMenu.prototype.getPath = () => {
-    return $("#pathSpan").text();
-}
+    return $('#pathSpan').text();
+};
 
 MonacoMenu.prototype.setPath = (path) => {
-    return $("#pathSpan").text(path);
-}
+    return $('#pathSpan').text(path);
+};
 
 MonacoMenu.prototype.setEnabled = (isEnable) => {
-    $("#saveButton").prop('disabled', !isEnable);
-}
+    $('#saveButton').prop('disabled', !isEnable);
+};
 
 function EditBookMonacoEditor(elem) {
     this.elem = elem;
@@ -212,7 +210,7 @@ EditBookMonacoEditor.prototype.open = function(path, data) {
         model = monaco.editor.createModel(data, null, uri);
         this.dirty = false;
         this.savedVersionId = model.getAlternativeVersionId();
-        
+
         NotifyModifyStatusChanged();
         this.lservice = {onChange: (a, b)=>{}};
         model.onDidChangeContent((change) => {
@@ -220,11 +218,11 @@ EditBookMonacoEditor.prototype.open = function(path, data) {
             this.dirty = this.savedVersionId !== model.getAlternativeVersionId();
             if(prev_dirty != this.dirty) {
                 NotifyModifyStatusChanged();
-            } 
+            }
 
             this.lservice.onChange(model, change);
         });
-        
+
 
         if (this._services === null) {
             console.warn('A file is opened before the language services are'
@@ -242,7 +240,6 @@ EditBookMonacoEditor.prototype.open = function(path, data) {
 
     this.editor.setModel(model);
     this.path = path;
-
 };
 
 EditBookMonacoEditor.prototype.save = function() {
@@ -264,7 +261,7 @@ EditBookMonacoEditor.prototype.save = function() {
         this.dirty = false;
         NotifyModifyStatusChanged();
 
-        toastr.info("saved");
+        toastr.info('saved');
         if (svc) {
             svc.didSave(model);
         }
@@ -273,12 +270,13 @@ EditBookMonacoEditor.prototype.save = function() {
 
 EditBookMonacoEditor.initializeModule = function() {
     var onInit = [];
-
 };
 
 EditBookMonacoEditor.prototype.init = function() {
     this.editor = monaco.editor.create(this.elem);
     this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, ()=>this.save());
-   this.editor.updateOptions({ 'theme' : 'vs-dark' });
-    this.editor.onDidFocusEditor(() => { NotifyFocusChanged(this); });
+    this.editor.updateOptions({'theme': 'vs-dark'});
+    this.editor.onDidFocusEditor(() => {
+        NotifyFocusChanged(this);
+    });
 };

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -7,18 +7,19 @@ function NotifyModifyStatusChanged() {
     g_menu.setEnabled(g_current.dirty);
 }
 
+// eslint-disable-next-line no-unused-vars
 function EditBook_NewEditor(elem, ws) {
     document.body.style.margin = '0';
     var menu = new MonacoMenu(elem);
 
-    var main_editor =  new EditBookMonacoEditor(menu.main_div);
+    var main_editor = new EditBookMonacoEditor(menu.main_div);
     var sub_editor = new EditBookMonacoEditor(menu.sub_div);
 
-    var onInit = InitializeModule();
-    onInit.push(() => { main_editor.init(); });
-    onInit.push(() => { sub_editor.init(); });
+    var onInit = initializeModule();
+    onInit.push(() => main_editor.init());
+    onInit.push(() => sub_editor.init());
     onInit.push((_, languageservice) => {
-        InitializeLanguageServices(ws, languageservice, function(services) {
+        initializeLanguageServices(ws, languageservice, function(services) {
             main_editor.registerLangServices(services);
             sub_editor.registerLangServices(services);
         });
@@ -28,10 +29,12 @@ function EditBook_NewEditor(elem, ws) {
     g_menu = menu;
 
     menu.save = () => g_current.save();
-    menu.split_window = (main_div, sub_div) => { main_editor.editor.layout(); sub_editor.editor.layout();
-         sub_editor.editor.setModel(main_editor.editor.getModel());
-         sub_editor.path = main_editor.path;
-         };
+    menu.split_window = (main_div, sub_div) => {
+        main_editor.editor.layout();
+        sub_editor.editor.layout();
+        sub_editor.editor.setModel(main_editor.editor.getModel());
+        sub_editor.path = main_editor.path;
+    };
     menu.unsplit_window = (main_div) => {
         if(g_current != main_editor) {
             // we want to detach sub_editor from div and re-attach to main_div.
@@ -57,7 +60,7 @@ function EditBook_NewEditor(elem, ws) {
     };
 }
 
-function InitializeModule() {
+function initializeModule() {
     function onAmdEnabled() {
         require.config({paths:
             {vs: '/editor/vs', languageservice: '/editor/languageservice'}});
@@ -81,7 +84,7 @@ function InitializeModule() {
     return onInit;
 }
 
-function InitializeLanguageServices(ws, languageservice, callback) {
+function initializeLanguageServices(ws, languageservice, callback) {
     function onLanguageServiceList(ev) {
         var data = ev.data;
         if (data[0] !== '3') {

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -1,42 +1,42 @@
 'use strict';
 
-var g_current;
-var g_menu;
+var gCurrent;
+var gMenu;
 
 function notifyModifyStatusChanged() {
-    g_menu.setEnabled(g_current.dirty);
+    gMenu.setEnabled(gCurrent.dirty);
 }
 
 // eslint-disable-next-line no-unused-vars
-function EditBook_NewEditor(elem, ws) {
+EditBook.newEditor = function(elem, ws) {
     document.body.style.margin = '0';
     var menu = new MonacoMenu(elem);
 
-    var main_editor = new EditBookMonacoEditor(menu.main_div);
-    var sub_editor = new EditBookMonacoEditor(menu.sub_div);
+    var mainEditor = new EditBookMonacoEditor(menu.mainDiv);
+    var subEditor = new EditBookMonacoEditor(menu.subDiv);
 
     var onInit = initializeModule();
-    onInit.push(() => main_editor.init());
-    onInit.push(() => sub_editor.init());
+    onInit.push(() => mainEditor.init());
+    onInit.push(() => subEditor.init());
     onInit.push((_, languageservice) => {
         initializeLanguageServices(ws, languageservice, function(services) {
-            main_editor.registerLangServices(services);
-            sub_editor.registerLangServices(services);
+            mainEditor.registerLangServices(services);
+            subEditor.registerLangServices(services);
         });
     });
 
-    g_current = main_editor;
-    g_menu = menu;
+    gCurrent = mainEditor;
+    gMenu = menu;
 
-    menu.save = () => g_current.save();
-    menu.split_window = (main_div, sub_div) => {
-        main_editor.editor.layout();
-        sub_editor.editor.layout();
-        sub_editor.editor.setModel(main_editor.editor.getModel());
-        sub_editor.path = main_editor.path;
+    menu.save = () => gCurrent.save();
+    menu.splitWindow = (mainDiv, subDiv) => {
+        mainEditor.editor.layout();
+        subEditor.editor.layout();
+        subEditor.editor.setModel(mainEditor.editor.getModel());
+        subEditor.path = mainEditor.path;
     };
-    menu.unsplit_window = (main_div) => {
-        if(g_current != main_editor) {
+    menu.unsplitWindow = (mainDiv) => {
+        if(gCurrent != mainEditor) {
             // we want to detach sub_editor from div and re-attach to main_div.
             // But I don't know how to do it. So just set model and path
             // from sub_editor. This lost scroll position information, etc.
@@ -44,19 +44,19 @@ function EditBook_NewEditor(elem, ws) {
 
             // var state = g_current.editor.saveViewState();
 
-            main_editor.editor.setModel(g_current.editor.getModel());
-            main_editor.path = g_current.path;
+            mainEditor.editor.setModel(gCurrent.editor.getModel());
+            mainEditor.path = gCurrent.path;
 
             // main_editor.restoreViewState(state);
         }
-        main_editor.editor.layout();
+        mainEditor.editor.layout();
     };
 
     return {
         init: ()=>{},
         open: (path, data, abspath) => {
             menu.setPath(path);
-            g_current.open(abspath, data);
+            gCurrent.open(abspath, data);
         },
     };
 }
@@ -106,14 +106,14 @@ function initializeLanguageServices(ws, languageservice, callback) {
 }
 
 function notifyFocusChanged(editor) {
-    g_current = editor;
-    g_menu.setPath(editor.path);
+    gCurrent = editor;
+    gMenu.setPath(editor.path);
 }
 
 // need to set
 // - mehu.save()
-// - menu.split_window = (main_div, sub_div) =>{}
-// - menu.unsplit_window = (main_div) => {}
+// - menu.splitWindow = (main_div, sub_div) =>{}
+// - menu.unsplitWindow = (main_div) => {}
 function MonacoMenu(holder) {
     var builder = [];
     builder.push(
@@ -126,14 +126,14 @@ function MonacoMenu(holder) {
     );
     holder.html(builder.join(''));
 
-    var main_div = document.getElementById('mainDiv');
-    this.main_div = main_div;
+    var mainDiv = document.getElementById('mainDiv');
+    this.mainDiv = mainDiv;
 
-    var sub_div = document.createElement('div');
-    sub_div.style.cssText = 'position: absolute; top:0px; bottom:0px';
-    sub_div.style.overflow = 'hidden';
-    sub_div.id = 'subDiv';
-    this.sub_div = sub_div;
+    var subDiv = document.createElement('div');
+    subDiv.style.cssText = 'position: absolute; top:0px; bottom:0px';
+    subDiv.style.overflow = 'hidden';
+    subDiv.id = 'subDiv';
+    this.subDiv = subDiv;
 
     var menu = this;
 
@@ -152,25 +152,25 @@ function MonacoMenu(holder) {
         // eslint-disable-next-line no-invalid-this
         if(this.checked) {
             // split
-            holder.append(sub_div);
+            holder.append(subDiv);
 
-            var width = main_div.clientWidth;
+            var width = mainDiv.clientWidth;
 
             var editorWidth = width / 2;
 
-            resize(main_div, 0, main_div.offsetTop, '50%');
-            resize(sub_div, editorWidth, main_div.offsetTop, '50%');
+            resize(mainDiv, 0, mainDiv.offsetTop, '50%');
+            resize(subDiv, editorWidth, mmainDivoffsetTop, '50%');
 
-            menu.split_window(main_div, sub_div);
+            menu.splitWindow(mainDiv, subDiv);
         } else {
             // unsplit
 
-            var width = main_div.clientWidth;
+            var width = mainDiv.clientWidth;
 
-            $(sub_div).remove();
-            resize(main_div, 0, main_div.top, '100%');
+            $(subDiv).remove();
+            resize(mainDiv, 0, mainDiv.top, '100%');
 
-            menu.unsplit_window(main_div);
+            menu.unsplitWindow(mainDiv);
         }
     });
 }
@@ -216,10 +216,10 @@ EditBookMonacoEditor.prototype.open = function(path, data) {
         notifyModifyStatusChanged();
         this.lservice = {onChange: (a, b)=>{}};
         model.onDidChangeContent((change) => {
-            var prev_dirty = this.dirty;
+            var prevDirty = this.dirty;
             this.dirty = (
                 this.savedVersionId !== model.getAlternativeVersionId());
-            if(prev_dirty != this.dirty) {
+            if(prevDirty != this.dirty) {
                 notifyModifyStatusChanged();
             }
 
@@ -260,7 +260,7 @@ EditBookMonacoEditor.prototype.save = function() {
     }
     // TODO: should use willSaveWaitUntil?
     // eslint-disable-next-line new-cap
-    EditBook_SaveFile(this.path, model.getValue(), () => {
+    EditBook.saveFile(this.path, model.getValue(), () => {
         this.savedVersionId = model.getAlternativeVersionId();
         this.dirty = false;
         notifyModifyStatusChanged();

--- a/editors/monaco/languageservice.js
+++ b/editors/monaco/languageservice.js
@@ -2,7 +2,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     var Promise = monaco.Promise;
 
     function registerLanguageService(params, wsHandler) {
-        var ClientClass = (params.protocol === 'TS') ? TSClient : LanguageClient;
+        var ClientClass =
+            (params.protocol === 'TS') ? TSClient : LanguageClient;
         var client = new ClientClass(params.lang, wsHandler);
         monaco.languages.onLanguage(params.lang, function() {
             client.init();
@@ -79,19 +80,23 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 monaco.languages.registerCodeActionProvider(lang, this);
             }
             if (capabilities.documentFormattingProvider) {
-                monaco.languages.registerDocumentFormattingEditProvider(lang, this);
+                monaco.languages.registerDocumentFormattingEditProvider(
+                    lang, this);
             }
             if (capabilities.documentRangeFormattingProvider) {
-                monaco.languages.registerDocumentRangeFormattingEditProvider(lang, this);
+                monaco.languages.registerDocumentRangeFormattingEditProvider(
+                    lang, this);
             }
             if (capabilities.documentOnTypeFormattingProvider) {
                 var opts = capabilities.documentOnTypeFormattingProvider;
                 this.autoFormatTriggerCharacters = [opts.firstTriggerCharacter];
                 if (opts.moreTriggerCharacters) {
                     Array.prototype.push.apply(
-                        this.autoFormatTriggerCharacters, opts.moreTriggerCharacters);
+                        this.autoFormatTriggerCharacters,
+                        opts.moreTriggerCharacters);
                 }
-                monaco.languages.registerOnTypeFormattingEditProvider(lang, this);
+                monaco.languages.registerOnTypeFormattingEditProvider(
+                    lang, this);
             }
             if (capabilities.documentLinkProvider) {
                 if (capabilities.documentLinkProvider.resolveProvider) {
@@ -131,8 +136,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             });
             if (token) {
                 token.onCancellationRequested(() => {
- p.cancel();
-});
+                    p.cancel();
+                });
             }
             return p.then(function(resp) {
                 if (resp.error) {
@@ -180,8 +185,14 @@ define('languageservice', ['vs/editor/editor.main'], function() {
 
     LanguageClient.prototype.rangeToLS = function(range) {
         return {
-            start: {line: range.startLineNumber - 1, character: range.startColumn - 1},
-            end: {line: range.endLineNumber - 1, character: range.endColumn - 1},
+            start: {
+                line: range.startLineNumber - 1,
+                character: range.startColumn - 1,
+            },
+            end: {
+                line: range.endLineNumber - 1,
+                character: range.endColumn - 1,
+            },
         };
     };
 
@@ -260,23 +271,26 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         this.notify('textDocument/didChange', params);
     };
 
-    LanguageClient.prototype.provideReferences = function(model, position, context, token) {
+    LanguageClient.prototype.provideReferences = function(
+        model, position, context, token) {
         var params = this.getDocumentParams(model, position);
         params.includeDeclaration = context.includeDeclaration;
-        return this.call('textDocument/references', params, token).then((refs) => {
-            if (!refs) {
-                return refs;
-            }
-            return refs.map((location) => this.locationToMonaco(location));
-        });
+        return this.call('textDocument/references', params, token)
+            .then((refs) => {
+                if (!refs) {
+                    return refs;
+                }
+                return refs.map((location) => this.locationToMonaco(location));
+            });
     };
 
-    LanguageClient.prototype.provideRenameEdits = function(model, position, newName, token) {
+    LanguageClient.prototype.provideRenameEdits = function(
+        model, position, newName, token) {
         var params = this.getDocumentParams(model, position);
         params.newName = newName;
         return this.call('textDocument/rename', params, token).then((edits) => {
             var results = [];
-            for (var key in edits.changes) {
+            Object.keys(edits.changes).forEach((key) => {
                 var cs = edits.changes[key];
                 var uri = monaco.Uri.parse(key);
                 cs.forEach((change) => {
@@ -286,26 +300,31 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                         newText: change.newText,
                     });
                 });
-            }
+            });
             return {edits: results};
         });
     };
 
-    LanguageClient.prototype.provideSignatureHelp = function(model, position, token) {
-        return this.call('textDocument/signatureHelp', this.getDocumentParams(model, position), token).then((help) => {
-            help.signatures.forEach((sig) => {
-                // parameters is optional in LS, but not optional in monaco.
-                if (!sig.parameters) {
-                    // I've seen python-language-server has 'params' field for 'parameters'.
-                    sig.parameters = sig.params || [];
-                }
+    LanguageClient.prototype.provideSignatureHelp = function(
+        model, position, token) {
+        var params = this.getDocumentParams(model, position);
+        return this.call('textDocument/signatureHelp', params, token)
+            .then((help) => {
+                help.signatures.forEach((sig) => {
+                    // parameters is optional in LS, but not optional in monaco.
+                    if (!sig.parameters) {
+                        // I've seen python-language-server has 'params' field
+                        // for 'parameters'.
+                        sig.parameters = sig.params || [];
+                    }
+                });
+                return help;
             });
-            return help;
-        });
     };
 
     LanguageClient.prototype.provideHover = function(model, position, token) {
-        return this.call('textDocument/hover', this.getDocumentParams(model, position), token).then((hover) => {
+        var params = this.getDocumentParams(model, position);
+        return this.call('textDocument/hover', params, token).then((hover) => {
             if (!hover) {
                 return hover;
             }
@@ -320,33 +339,47 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     LanguageClient.prototype.provideDocumentSymbols = function(model, token) {
-        return this.call('textDocument/documentSymbol', this.getDocumentParams(model), token).then((syms) => {
-            syms.forEach((sym) => {
-                // I don't know why, but the number is shifted between LS and VS.
-                sym.kind = sym.kind - 1;
-                sym.location = this.locationToMonaco(sym.location);
+        var params = this.getDocumentParams(model);
+        return this.call('textDocument/documentSymbol', params, token)
+            .then((syms) => {
+                syms.forEach((sym) => {
+                    // I don't know why, but the number is shifted
+                    // between LS and VS.
+                    sym.kind = sym.kind - 1;
+                    sym.location = this.locationToMonaco(sym.location);
+                });
+                return syms;
             });
-            return syms;
-        });
     };
 
-    LanguageClient.prototype.provideDocumentHighlights = function(model, position, token) {
-        return this.call('textDocument/documentHighlight', this.getDocumentParams(model, position), token).then((highlights) => {
-            return highlights.map((highlight) => {
-                return {range: this.rangeToMonaco(highlight.range), kind: highlight.kind - 1};
+    LanguageClient.prototype.provideDocumentHighlights = function(
+        model, position, token) {
+        var params = this.getDocumentParams(model, position);
+        return this.call(
+            'textDocument/documentHighlight', params, token)
+            .then((highlights) => {
+                return highlights.map((highlight) => {
+                    return {
+                        range: this.rangeToMonaco(highlight.range),
+                        kind: highlight.kind - 1,
+                    };
+                });
             });
-        });
     };
 
-    LanguageClient.prototype.provideDefinition = function(model, position, token) {
-        return this.call('textDocument/definition', this.getDocumentParams(model, position), token).then((def) => {
-            if (!Array.isArray(def)) {
-                return this.locationToMonaco(def);
-            } else {
-                return def.map((location) => this.locationToMonaco(location));
-            }
-            return def;
-        });
+    LanguageClient.prototype.provideDefinition = function(
+        model, position, token) {
+        var params = this.getDocumentParams(model, position);
+        return this.call('textDocument/definition', params, token)
+            .then((def) => {
+                if (!Array.isArray(def)) {
+                    return this.locationToMonaco(def);
+                } else {
+                    return def.map(
+                        (location) => this.locationToMonaco(location));
+                }
+                return def;
+            });
     };
 
     LanguageClient.prototype.codeLensToLS = function(lens) {
@@ -362,12 +395,15 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     LanguageClient.prototype.provideCodeLenses = function(model, token) {
-        return this.call('textDocument/codeLens', this.getDocumentParams(model), token).then((lenses) => {
-            return lenses.map((lens) => this.codeLensToLS(lens));
-        });
+        var params = this.getDocumentParams(model);
+        return this.call('textDocument/codeLens', params, token)
+            .then((lenses) => {
+                return lenses.map((lens) => this.codeLensToLS(lens));
+            });
     };
 
-    LanguageClient.prototype.resolveCodeLensImpl = function(model, codeLens, token) {
+    LanguageClient.prototype.resolveCodeLensImpl = function(
+        model, codeLens, token) {
         var params = {range: this.rangeToLS(codeLens.range)};
         if (codeLens.data) {
             params.data = codeLens.data;
@@ -379,10 +415,12 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 arguments: codeLens.command.arguments,
             };
         }
-        return this.call('codeLens/resolve', params, token).then((codeLens) => this.codeLensToLS(codeLens));
+        return this.call('codeLens/resolve', params, token).then(
+            (codeLens) => this.codeLensToLS(codeLens));
     };
 
-    LanguageClient.prototype.provideCodeActions = function(model, position, context, token) {
+    LanguageClient.prototype.provideCodeActions = function(
+        model, position, context, token) {
         var params = this.getDocumentParams(model, position);
         params.context = [];
         context.markers.forEach((marker) => {
@@ -393,85 +431,106 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             diag.message = marker.message;
             params.context.push(diag);
         });
-        return this.call('textDocument/codeAction', params, token).then((commands) => commands.map((command) => {
-            return {
-                command: {
-                    id: command.command,
-                    title: command.title,
-                    arguments: command.arguments,
-                },
-                score: 0,
-            };
-        }));
+        return this.call('textDocument/codeAction', params, token)
+            .then((commands) => {
+                return commands.map((command) => {
+                    return {
+                        command: {
+                            id: command.command,
+                            title: command.title,
+                            arguments: command.arguments,
+                        },
+                        score: 0,
+                    };
+                });
+            });
     };
 
-    LanguageClient.prototype.provideDocumentFormattingEdits = function(model, options, token) {
+    LanguageClient.prototype.provideDocumentFormattingEdits = function(
+        model, options, token) {
         var params = this.getDocumentParams(model);
         params.options = options;
-        return this.call('textDocument/formatting', params, token).then((edits) => {
-            edits.forEach((edit) => {
-                edit.range = this.rangeToMonaco(edit.range);
+        return this.call('textDocument/formatting', params, token)
+            .then((edits) => {
+                edits.forEach((edit) => {
+                    edit.range = this.rangeToMonaco(edit.range);
+                });
+                return edits;
             });
-            return edits;
-        });
     };
 
-    LanguageClient.prototype.provideDocumentRangeFormattingEdits = function(model, range, options, token) {
+    LanguageClient.prototype.provideDocumentRangeFormattingEdits = function(
+        model, range, options, token) {
         var params = this.getDocumentParams(model);
         params.range = this.rangeToLS(range);
         params.options = options;
-        return this.call('textDocument/rangeFormatting', params, token).then((edits) => {
-            edits.forEach((edit) => {
-                edit.range = this.rangeToMonaco(edit.range);
+        return this.call('textDocument/rangeFormatting', params, token)
+            .then((edits) => {
+                edits.forEach((edit) => {
+                    edit.range = this.rangeToMonaco(edit.range);
+                });
+                return edits;
             });
-            return edits;
-        });
     };
 
-    LanguageClient.prototype.provideOnTypeFormattingEdits = function(model, position, ch, options, token) {
+    LanguageClient.prototype.provideOnTypeFormattingEdits = function(
+        model, position, ch, options, token) {
         var params = this.getDocumentParams(model, position);
         params.ch = ch;
         params.options = options;
-        return this.call('textDocument/onTypeFormatting', params, token).then((edits) => {
-            edits.forEach((edit) => {
-                edit.range = this.rangeToMonaco(edit.range);
+        return this.call('textDocument/onTypeFormatting', params, token)
+            .then((edits) => {
+                edits.forEach((edit) => {
+                    edit.range = this.rangeToMonaco(edit.range);
+                });
+                return edits;
             });
-            return edits;
-        });
     };
 
     LanguageClient.prototype.provideLinks = function(model, token) {
-        return this.call('textDocument/documentLink', this.getDocumentParams(model), token).then((links) => {
-            links = links || [];
-            return links.map((link) => {
-                return {
-                    range: this.rangeToMonaco(link.range),
-                    uri: monaco.Uri.parse(link.target),
-                };
+        var params = this.getDocumentParams(model);
+        return this.call('textDocument/documentLink', params, token)
+            .then((links) => {
+                links = links || [];
+                return links.map((link) => {
+                    return {
+                        range: this.rangeToMonaco(link.range),
+                        uri: monaco.Uri.parse(link.target),
+                    };
+                });
             });
-        });
     };
 
     LanguageClient.prototype.resolveLinkImpl = function(link, token) {
-        var params = {range: this.rangeToLS(link.range), target: link.uri.toString()};
+        var params = {
+            range: this.rangeToLS(link.range),
+            target: link.uri.toString(),
+        };
         return this.call('documentLink/resolve', params, token).then((link) => {
-            return {range: this.rangeToMonaco(link.range), uri: monaco.Uri.parse(link.target)};
+            return {
+                range: this.rangeToMonaco(link.range),
+                uri: monaco.Uri.parse(link.target),
+            };
         });
     };
 
-    LanguageClient.prototype.provideCompletionItems = function(model, position, token) {
-        return this.call('textDocument/completion', this.getDocumentParams(model, position), token).then((comps) => {
-            var items = Array.isArray(comps) ? comps : comps.items;
-            items.forEach((item) => {
-                if (item.insertText && item.insertTextFormat == 2) {
-                    item.insertText = {value: item.insertText};
-                }
-                if (item.textEdit) {
-                    item.textEdit.range = this.rangeToMonaco(item.textEdit.range);
-                }
+    LanguageClient.prototype.provideCompletionItems = function(
+        model, position, token) {
+        var params = this.getDocumentParams(model, position);
+        return this.call('textDocument/completion', params, token)
+            .then((comps) => {
+                var items = Array.isArray(comps) ? comps : comps.items;
+                items.forEach((item) => {
+                    if (item.insertText && item.insertTextFormat == 2) {
+                        item.insertText = {value: item.insertText};
+                    }
+                    if (item.textEdit) {
+                        item.textEdit.range = this.rangeToMonaco(
+                            item.textEdit.range);
+                    }
+                });
+                return comps;
             });
-            return comps;
-        });
     };
 
     LanguageClient.prototype.resolveCompletionItemImpl = function(item, token) {
@@ -501,7 +560,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         wsHandler.registerClient(lang, this);
     }
 
-    TSClient.prototype.send = function(command, arguments, typ, waitResponse, token) {
+    TSClient.prototype.send = function(
+        command, arguments, typ, waitResponse, token) {
         var msg = {
             seq: this._id++,
             command: command,
@@ -561,7 +621,6 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     TSClient.prototype.init = function() {
-        // TODO: register.
         monaco.languages.registerReferenceProvider(this._lang, this);
         monaco.languages.registerRenameProvider(this._lang, this);
         monaco.languages.registerSignatureHelpProvider(this._lang, this);
@@ -570,13 +629,16 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         monaco.languages.registerDocumentHighlightProvider(this._lang, this);
         monaco.languages.registerDefinitionProvider(this._lang, this);
         monaco.languages.registerImplementationProvider(this._lang, this);
-        monaco.languages.registerDocumentRangeFormattingEditProvider(this._lang, this);
+        monaco.languages.registerDocumentRangeFormattingEditProvider(
+            this._lang, this);
         monaco.languages.registerOnTypeFormattingEditProvider(this._lang, this);
         monaco.languages.registerCompletionItemProvider(this._lang, this);
     };
 
     TSClient.prototype.onOpen = function(model) {
-        this.notify('open', {file: model.uri.path, fileContent: model.getValue()});
+        this.notify(
+            'open', {file: model.uri.path, fileContent: model.getValue()}
+        );
     };
 
     TSClient.prototype.willSave = function(model) {
@@ -625,11 +687,16 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     TSClient.prototype.fileSpanToMonaco = function(span) {
-        return {uri: monaco.Uri.file(span.file), range: this.rangeToMonaco(span)};
+        return {
+            uri: monaco.Uri.file(span.file),
+            range: this.rangeToMonaco(span),
+        };
     };
 
-    TSClient.prototype.provideReferences = function(model, position, context, token) {
-        return this.call('references', this.fileLocation(model, position), token).then((refs) => {
+    TSClient.prototype.provideReferences = function(
+        model, position, context, token) {
+        var params = this.fileLocation(model, position);
+        return this.call('references', params, token).then((refs) => {
             var results = [];
             refs.refs.forEach((ref) => {
                 if (!ref.isDefinition || context.includeDeclaration) {
@@ -643,10 +710,13 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         });
     };
 
-    TSClient.prototype.provideRenameEdits = function(model, position, newName, token) {
-        return this.call('rename', this.fileLocation(model, position), token).then((rename) => {
+    TSClient.prototype.provideRenameEdits = function(
+        model, position, newName, token) {
+        var params = this.fileLocation(model, position);
+        return this.call('rename', params, token).then((rename) => {
             if (!rename.info.canRename) {
-                return {edits: [], rejectionReason: rename.info.localizedErrorMessage};
+                var msg = rename.info.localizedErrorMessage;
+                return {edits: [], rejectionReason: msg};
             }
             var edits = [];
             rename.locs.forEach((fileLoc) => {
@@ -664,36 +734,38 @@ define('languageservice', ['vs/editor/editor.main'], function() {
 
     TSClient.prototype.signatureHelpTriggerCharacters = ['('];
     TSClient.prototype.provideSignatureHelp = function(model, position, token) {
-        return this.call(
-            'signatureHelp', this.fileLocation(model, position), token).then((help) => {
-                var sigs = [];
-                help.items.forEach((item) => {
-                    sigs.push({
-                        label: item.displayParts.map((p) => p.text).join(),
-                        documentation: item.documentation.map(
-                            (doc) => doc.text).join(),
-                        parameters: item.parameters.map((p) => {
-                            return {
-                                label: p.name,
-                                documentation: p.documentation.map(
-                                    (doc) => doc.text).join('\n'),
-                            };
-                        }),
-                    });
+        var params = this.fileLocation(model, position);
+        return this.call('signatureHelp', params, token).then((help) => {
+            var sigs = [];
+            help.items.forEach((item) => {
+                sigs.push({
+                    label: item.displayParts.map((p) => p.text).join(),
+                    documentation: item.documentation.map(
+                        (doc) => doc.text).join(),
+                    parameters: item.parameters.map((p) => {
+                        return {
+                            label: p.name,
+                            documentation: p.documentation.map(
+                                (doc) => doc.text).join('\n'),
+                        };
+                    }),
                 });
-                return {
-                    signatures: sigs,
-                    activeSignature: help.selectedItemIndex,
-                    activeParameter: help.argumentIndex,
-                };
             });
+            return {
+                signatures: sigs,
+                activeSignature: help.selectedItemIndex,
+                activeParameter: help.argumentIndex,
+            };
+        });
     };
 
     TSClient.prototype.provideHover = function(model, position, token) {
-        return this.call('quickinfo', this.fileLocation(model, position), token).then((info) => {
+        var params = this.fileLocation(model, position);
+        return this.call('quickinfo', params, token).then((info) => {
             contents = [{language: this._lang, value: info.displayString}];
             if (info.documentation) {
-                contents.push({language: this._lang, value: info.documentation});
+                contents.push(
+                    {language: this._lang, value: info.documentation});
             }
             return {contents: contents, range: this.rangeToMonaco(info)};
         });
@@ -731,7 +803,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             'directory': undefined,
             'external module name': monaco.languages.SymbolKind.Module,
         };
-        return this.call('navbar', this.fileLocation(model), token).then((items) => {
+        var params = this.fileLocation(model);
+        return this.call('navbar', params, token).then((items) => {
             var results = [];
             items.forEach((item) => {
                 if (kindMapping[item.kind] === undefined) {
@@ -741,7 +814,10 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 results.push({
                     name: item.text,
                     kind: kindMapping[item.kind],
-                    location: {uri: model.uri, range: this.rangeToMonaco(item.spans[0])},
+                    location: {
+                        uri: model.uri,
+                        range: this.rangeToMonaco(item.spans[0]),
+                    },
                 });
             });
             console.log(results);
@@ -749,7 +825,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         });
     };
 
-    TSClient.prototype.provideDocumentHighlights = function(model, position, token) {
+    TSClient.prototype.provideDocumentHighlights = function(
+        model, position, token) {
         var params = this.fileLocation(model, position);
         params.filesToSearch = [];
         var kindMapping = {
@@ -758,31 +835,42 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             reference: monaco.languages.DocumentHighlightKind.Read,
             writtenReference: monaco.languages.DocumentHighlightKind.Write,
         };
-        return this.call('documentHighlights', params, token).then((highlights) => {
-            return highlights.map((highlight) => {
-                var span = highlight.highlightSpans[0];
-                return {range: this.rangeToMonaco(span), kind: kindMapping[span.kind]};
+        return this.call('documentHighlights', params, token)
+            .then((highlights) => {
+                return highlights.map((highlight) => {
+                    var span = highlight.highlightSpans[0];
+                    return {
+                        range: this.rangeToMonaco(span),
+                        kind: kindMapping[span.kind],
+                    };
+                });
             });
-        });
     };
 
     TSClient.prototype.provideDefinition = function(model, position, token) {
-        return this.call('definition', this.fileLocation(model, position), token).then((def) => {
+        var params = this.fileLocation(model, position);
+        return this.call('definition', params, token).then((def) => {
             return def.map((d) => this.fileSpanToMonaco(d));
         });
     };
 
-    TSClient.prototype.provideImplementation = function(model, position, token) {
-        return this.call('implementation', this.fileLocation(model, position), token).then((impl) => {
+    TSClient.prototype.provideImplementation = function(
+        model, position, token) {
+        var params = this.fileLocation(model, position);
+        return this.call('implementation', params, token).then((impl) => {
             return impl.map((i) => this.fileSpantoMonaco(i));
         });
     };
 
-    TSClient.prototype.provideDocumentRangeFormattingEdits = function(model, range, options, token) {
+    TSClient.prototype.provideDocumentRangeFormattingEdits = function(
+        model, range, options, token) {
         var params = this.fileLocation(model, range.start);
         params.endLine = range.endLineNumber;
         params.endOffset = range.endColumn;
-        params.options = {tabSize: options.tabSize, convertTabsToSpaces: options.insertSpaces};
+        params.options = {
+            tabSize: options.tabSize,
+            convertTabsToSpaces: options.insertSpaces,
+        };
         return this.call('format', params, token).then((edits) => {
             return edits.map((edit) => {
                 return {range: this.rangeToMonaco(edit), text: edit.newText};
@@ -791,10 +879,14 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     TSClient.prototype.autoFormatTriggerCharacters = ['\n', ';', '}'];
-    TSClient.prototype.provideOnTypeFormattingEdits = function(model, position, ch, options, token) {
+    TSClient.prototype.provideOnTypeFormattingEdits = function(
+        model, position, ch, options, token) {
         var params = this.fileLocation(model, position);
         params.key = ch;
-        params.options = {tabSize: options.tabSize, convertTabsToSpaces: options.insertSpaces};
+        params.options = {
+            tabSize: options.tabSize,
+            convertTabsToSpaces: options.insertSpaces,
+        };
         return this.call('formatonkey', params, token).then((edits) => {
             return edits.map((edit) => {
                 return {range: this.rangeToMonaco(edit), text: edit.newText};
@@ -803,7 +895,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     TSClient.prototype.triggerCharacters = ['.'];
-    TSClient.prototype.provideCompletionItems = function(model, position, token) {
+    TSClient.prototype.provideCompletionItems = function(
+        model, position, token) {
         var kindMapping = {
             'warning': monaco.languages.CompletionItemKind.Value,
             'keyword': monaco.languages.CompletionItemKind.Keyword,
@@ -882,5 +975,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         console.log(msg);
         this._ws.send('2' + lang + JSON.stringify(msg));
     };
-    return {WsHandler: WsHandler, registerLanguageService: registerLanguageService};
+    return {
+        WsHandler: WsHandler,
+        registerLanguageService: registerLanguageService,
+    };
 });

--- a/editors/monaco/languageservice.js
+++ b/editors/monaco/languageservice.js
@@ -27,12 +27,12 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             synchronization: {
                 willSave: true,
                 willSaveWaitUntil: true,
-                didSave: true
+                didSave: true,
             },
             completion: {
-                comptetionItem: {snippetSupport: true}
-            }
-        }
+                comptetionItem: {snippetSupport: true},
+            },
+        };
         var capabilities = {textDocument: textDocumentCapabilities};
         this.call('initialize', {capabilities: capabilities}).then((resp) => {
             console.log(this);
@@ -110,13 +110,13 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 monaco.languages.registerCompletionItemProvider(lang, this);
             }
         });
-    }
+    };
 
     LanguageClient.prototype.send = function(method, params, token, withId) {
         var msg = {
             jsonrpc: '2.0',
             method: method,
-            params: params
+            params: params,
         };
         if (withId) {
             msg.id = this._id++;
@@ -130,7 +130,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 delete this._responseWaiters[key];
             });
             if (token) {
-                token.onCancellationRequested(() => { p.cancel(); });
+                token.onCancellationRequested(() => {
+ p.cancel();
+});
             }
             return p.then(function(resp) {
                 if (resp.error) {
@@ -179,7 +181,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     LanguageClient.prototype.rangeToLS = function(range) {
         return {
             start: {line: range.startLineNumber - 1, character: range.startColumn - 1},
-            end: {line: range.endLineNumber - 1, character: range.endColumn - 1}
+            end: {line: range.endLineNumber - 1, character: range.endColumn - 1},
         };
     };
 
@@ -196,14 +198,14 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             startLineNumber: range.start.line + 1,
             startColumn: range.start.character + 1,
             endLineNumber: range.end.line + 1,
-            endColumn: range.end.character + 1
+            endColumn: range.end.character + 1,
         };
     };
 
     LanguageClient.prototype.locationToMonaco = function(location) {
         return {
             uri: monaco.Uri.parse(location.uri),
-            range: this.rangeToMonaco(location.range)
+            range: this.rangeToMonaco(location.range),
         };
     };
 
@@ -212,7 +214,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             uri: model.uri.toString(),
             languageId: model.getModeId(),
             version: model.getVersionId(),
-            text: model.getValue()
+            text: model.getValue(),
         };
         this.notify('textDocument/didOpen', {textDocument: doc});
     };
@@ -252,7 +254,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             params.contentChanges = [{
                 range: this.rangeToLS(change.range),
                 rangeLength: change.rangeLength,
-                text: change.text
+                text: change.text,
             }];
         }
         this.notify('textDocument/didChange', params);
@@ -262,7 +264,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         var params = this.getDocumentParams(model, position);
         params.includeDeclaration = context.includeDeclaration;
         return this.call('textDocument/references', params, token).then((refs) => {
-            if (!refs) { return refs; }
+            if (!refs) {
+                return refs;
+            }
             return refs.map((location) => this.locationToMonaco(location));
         });
     };
@@ -279,7 +283,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                     results.push({
                         uri: uri,
                         range: this.rangeToMonaco(change.range),
-                        newText: change.newText
+                        newText: change.newText,
                     });
                 });
             }
@@ -351,7 +355,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             lens.command = {
                 id: lens.command.command,
                 title: lens.command.title,
-                arguments: lens.command.arguments
+                arguments: lens.command.arguments,
             };
         }
         return lens;
@@ -372,7 +376,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             params.command = {
                 command: codeLens.command.id,
                 title: codeLens.command.title,
-                arguments: codeLens.command.arguments
+                arguments: codeLens.command.arguments,
             };
         }
         return this.call('codeLens/resolve', params, token).then((codeLens) => this.codeLensToLS(codeLens));
@@ -394,9 +398,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 command: {
                     id: command.command,
                     title: command.title,
-                    arguments: command.arguments
+                    arguments: command.arguments,
                 },
-                score: 0
+                score: 0,
             };
         }));
     };
@@ -405,7 +409,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         var params = this.getDocumentParams(model);
         params.options = options;
         return this.call('textDocument/formatting', params, token).then((edits) => {
-            edits.forEach((edit) => { edit.range = this.rangeToMonaco(edit.range); });
+            edits.forEach((edit) => {
+                edit.range = this.rangeToMonaco(edit.range);
+            });
             return edits;
         });
     };
@@ -415,7 +421,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         params.range = this.rangeToLS(range);
         params.options = options;
         return this.call('textDocument/rangeFormatting', params, token).then((edits) => {
-            edits.forEach((edit) => { edit.range = this.rangeToMonaco(edit.range); });
+            edits.forEach((edit) => {
+                edit.range = this.rangeToMonaco(edit.range);
+            });
             return edits;
         });
     };
@@ -425,7 +433,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         params.ch = ch;
         params.options = options;
         return this.call('textDocument/onTypeFormatting', params, token).then((edits) => {
-            edits.forEach((edit) => { edit.range = this.rangeToMonaco(edit.range); });
+            edits.forEach((edit) => {
+                edit.range = this.rangeToMonaco(edit.range);
+            });
             return edits;
         });
     };
@@ -436,16 +446,16 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             return links.map((link) => {
                 return {
                     range: this.rangeToMonaco(link.range),
-                    uri: monaco.Uri.parse(link.target)
+                    uri: monaco.Uri.parse(link.target),
                 };
             });
         });
     };
 
     LanguageClient.prototype.resolveLinkImpl = function(link, token) {
-        var params = { range: this.rangeToLS(link.range), target: link.uri.toString() };
+        var params = {range: this.rangeToLS(link.range), target: link.uri.toString()};
         return this.call('documentLink/resolve', params, token).then((link) => {
-            return { range: this.rangeToMonaco(link.range), uri: monaco.Uri.parse(link.target) };
+            return {range: this.rangeToMonaco(link.range), uri: monaco.Uri.parse(link.target)};
         });
     };
 
@@ -454,7 +464,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             var items = Array.isArray(comps) ? comps : comps.items;
             items.forEach((item) => {
                 if (item.insertText && item.insertTextFormat == 2) {
-                    item.insertText = { value: item.insertText };
+                    item.insertText = {value: item.insertText};
                 }
                 if (item.textEdit) {
                     item.textEdit.range = this.rangeToMonaco(item.textEdit.range);
@@ -474,7 +484,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
         }
         return this.call('completionItem/resolve', item, token).then((item) => {
             if (item.insertText && item.insertTextFormat == 2) {
-                item.insertText = { value: item.insertText };
+                item.insertText = {value: item.insertText};
             }
             if (item.textEdit) {
                 item.textEdit.range = this.rangeToMonaco(item.textEdit.range);
@@ -496,7 +506,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             seq: this._id++,
             command: command,
             arguments: arguments,
-            type: typ
+            type: typ,
         };
         this._wsHandler.send(this._lang, msg);
         if (waitResponse) {
@@ -507,7 +517,9 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 delete this._responseWaiters[key];
             });
             if (token) {
-                token.onCancellationRequested(() => { p.cancel(); });
+                token.onCancellationRequested(() => {
+                    p.cancel();
+                });
             }
             return p.then(function(resp) {
                 if (!resp.success) {
@@ -564,7 +576,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     };
 
     TSClient.prototype.onOpen = function(model) {
-        this.notify('open', { file: model.uri.path, fileContent: model.getValue() });
+        this.notify('open', {file: model.uri.path, fileContent: model.getValue()});
     };
 
     TSClient.prototype.willSave = function(model) {
@@ -582,13 +594,13 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             offset: change.range.startColumn,
             endLine: change.range.endLineNumber,
             endOffset: change.range.endColumn,
-            insertString: change.text
+            insertString: change.text,
         };
         this.notify('change', params);
     };
 
     TSClient.prototype.fileLocation = function(model, position) {
-        var params = { file: model.uri.path };
+        var params = {file: model.uri.path};
         if (position) {
             params.line = position.lineNumber;
             params.offset = position.column;
@@ -598,8 +610,8 @@ define('languageservice', ['vs/editor/editor.main'], function() {
 
     TSClient.prototype.rangeToTS = function(range) {
         return {
-            start: { line: range.startLineNumber, offset: range.startColumn },
-            end: { line: range.endLineNumber, offset: range.endColumn }
+            start: {line: range.startLineNumber, offset: range.startColumn},
+            end: {line: range.endLineNumber, offset: range.endColumn},
         };
     };
 
@@ -608,12 +620,12 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             startLineNumber: range.start.line,
             startColumn: range.start.offset,
             endLineNumber: range.end.line,
-            endColumn: range.end.offset
+            endColumn: range.end.offset,
         };
     };
 
     TSClient.prototype.fileSpanToMonaco = function(span) {
-        return { uri: monaco.Uri.file(span.file), range: this.rangeToMonaco(span) };
+        return {uri: monaco.Uri.file(span.file), range: this.rangeToMonaco(span)};
     };
 
     TSClient.prototype.provideReferences = function(model, position, context, token) {
@@ -623,7 +635,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 if (!ref.isDefinition || context.includeDeclaration) {
                     results.push({
                         uri: monaco.Uri.file(ref.file),
-                        range: this.rangetoMonaco(ref)
+                        range: this.rangetoMonaco(ref),
                     });
                 }
             });
@@ -634,7 +646,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     TSClient.prototype.provideRenameEdits = function(model, position, newName, token) {
         return this.call('rename', this.fileLocation(model, position), token).then((rename) => {
             if (!rename.info.canRename) {
-                return { edits: [], rejectionReason: rename.info.localizedErrorMessage };
+                return {edits: [], rejectionReason: rename.info.localizedErrorMessage};
             }
             var edits = [];
             rename.locs.forEach((fileLoc) => {
@@ -642,11 +654,11 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                     edits.push({
                         resource: monaco.Uri.file(fileLoc.file),
                         range: this.rangeToMonaco(loc),
-                        newText: newName
+                        newText: newName,
                     });
                 });
             });
-            return { edits: edits };
+            return {edits: edits};
         });
     };
 
@@ -664,60 +676,60 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                             return {
                                 label: p.name,
                                 documentation: p.documentation.map(
-                                    (doc) => doc.text).join('\n')
+                                    (doc) => doc.text).join('\n'),
                             };
-                        })
+                        }),
                     });
                 });
                 return {
                     signatures: sigs,
                     activeSignature: help.selectedItemIndex,
-                    activeParameter: help.argumentIndex
+                    activeParameter: help.argumentIndex,
                 };
             });
     };
 
     TSClient.prototype.provideHover = function(model, position, token) {
         return this.call('quickinfo', this.fileLocation(model, position), token).then((info) => {
-            contents = [{ language: this._lang, value: info.displayString }];
+            contents = [{language: this._lang, value: info.displayString}];
             if (info.documentation) {
-                contents.push({ language: this._lang, value: info.documentation });
+                contents.push({language: this._lang, value: info.documentation});
             }
-            return { contents: contents, range: this.rangeToMonaco(info) };
+            return {contents: contents, range: this.rangeToMonaco(info)};
         });
     };
 
     TSClient.prototype.provideDocumentSymbols = function(model, token) {
         var kindMapping = {
-            keyword: undefined,
-            script: undefined,
-            "module": monaco.languages.SymbolKind.Module,
-            "class": monaco.languages.SymbolKind.Class,
-            "local class": monaco.languages.SymbolKind.Class,
-            "interface": monaco.languages.SymbolKind.Interface,
-            type: undefined,
-            enum: monaco.languages.SymbolKind.Enum,
-            "var": monaco.languages.SymbolKind.Variable,
-            "local var": monaco.languages.SymbolKind.Variable,
-            "function": monaco.languages.SymbolKind.Function,
-            "local function": monaco.languages.SymbolKind.Function,
-            "method": monaco.languages.SymbolKind.Method,
-            "getter": monaco.languages.SymbolKind.Property,
-            "setter": monaco.languages.SymbolKind.Method,
-            "property": monaco.languages.SymbolKind.Property,
-            "constructor": monaco.languages.SymbolKind.Constructor,
-            call: undefined,
-            index: undefined,
-            "construct": monaco.languages.SymbolKind.Constructor,
-            parameter: undefined,
-            "type parameter": undefined,
-            "primitive type": undefined,
-            "label": monaco.languages.SymbolKind.Constant,
-            "alias": monaco.languages.SymbolKind.Variable,
-            "const": monaco.languages.SymbolKind.Constant,
-            "let": monaco.languages.SymbolKind.Variable,
-            "directory": undefined,
-            "external module name": monaco.languages.SymbolKind.Module
+            'keyword': undefined,
+            'script': undefined,
+            'module': monaco.languages.SymbolKind.Module,
+            'class': monaco.languages.SymbolKind.Class,
+            'local class': monaco.languages.SymbolKind.Class,
+            'interface': monaco.languages.SymbolKind.Interface,
+            'type': undefined,
+            'enum': monaco.languages.SymbolKind.Enum,
+            'var': monaco.languages.SymbolKind.Variable,
+            'local var': monaco.languages.SymbolKind.Variable,
+            'function': monaco.languages.SymbolKind.Function,
+            'local function': monaco.languages.SymbolKind.Function,
+            'method': monaco.languages.SymbolKind.Method,
+            'getter': monaco.languages.SymbolKind.Property,
+            'setter': monaco.languages.SymbolKind.Method,
+            'property': monaco.languages.SymbolKind.Property,
+            'constructor': monaco.languages.SymbolKind.Constructor,
+            'call': undefined,
+            'index': undefined,
+            'construct': monaco.languages.SymbolKind.Constructor,
+            'parameter': undefined,
+            'type parameter': undefined,
+            'primitive type': undefined,
+            'label': monaco.languages.SymbolKind.Constant,
+            'alias': monaco.languages.SymbolKind.Variable,
+            'const': monaco.languages.SymbolKind.Constant,
+            'let': monaco.languages.SymbolKind.Variable,
+            'directory': undefined,
+            'external module name': monaco.languages.SymbolKind.Module,
         };
         return this.call('navbar', this.fileLocation(model), token).then((items) => {
             var results = [];
@@ -729,7 +741,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 results.push({
                     name: item.text,
                     kind: kindMapping[item.kind],
-                    location: { uri: model.uri, range: this.rangeToMonaco(item.spans[0]) }
+                    location: {uri: model.uri, range: this.rangeToMonaco(item.spans[0])},
                 });
             });
             console.log(results);
@@ -744,12 +756,12 @@ define('languageservice', ['vs/editor/editor.main'], function() {
             none: monaco.languages.DocumentHighlightKind.Text,
             definition: monaco.languages.DocumentHighlightKind.Read,
             reference: monaco.languages.DocumentHighlightKind.Read,
-            writtenReference: monaco.languages.DocumentHighlightKind.Write
+            writtenReference: monaco.languages.DocumentHighlightKind.Write,
         };
         return this.call('documentHighlights', params, token).then((highlights) => {
             return highlights.map((highlight) => {
                 var span = highlight.highlightSpans[0];
-                return { range: this.rangeToMonaco(span), kind: kindMapping[span.kind] };
+                return {range: this.rangeToMonaco(span), kind: kindMapping[span.kind]};
             });
         });
     };
@@ -793,28 +805,28 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     TSClient.prototype.triggerCharacters = ['.'];
     TSClient.prototype.provideCompletionItems = function(model, position, token) {
         var kindMapping = {
-            warning: monaco.languages.CompletionItemKind.Value,
-            keyword: monaco.languages.CompletionItemKind.Keyword,
-            "module": monaco.languages.CompletionItemKind.Module,
-            "class": monaco.languages.CompletionItemKind.Class,
-            "local class": monaco.languages.CompletionItemKind.Class,
-            "interface": monaco.languages.CompletionItemKind.Interface,
-            enum: monaco.languages.CompletionItemKind.Enum,
-            "var": monaco.languages.CompletionItemKind.Variable,
-            "local var": monaco.languages.CompletionItemKind.Variable,
-            "function": monaco.languages.CompletionItemKind.Function,
-            "local function": monaco.languages.CompletionItemKind.Function,
-            "method": monaco.languages.CompletionItemKind.Method,
-            "getter": monaco.languages.CompletionItemKind.Property,
-            "setter": monaco.languages.CompletionItemKind.Method,
-            "property": monaco.languages.CompletionItemKind.Property,
-            "constructor": monaco.languages.CompletionItemKind.Constructor,
-            "construct": monaco.languages.CompletionItemKind.Constructor,
-            "label": monaco.languages.CompletionItemKind.Variable,
-            "alias": monaco.languages.CompletionItemKind.Variable,
-            "const": monaco.languages.CompletionItemKind.Variable,
-            "let": monaco.languages.CompletionItemKind.Variable,
-            "external module name": monaco.languages.CompletionItemKind.Module
+            'warning': monaco.languages.CompletionItemKind.Value,
+            'keyword': monaco.languages.CompletionItemKind.Keyword,
+            'module': monaco.languages.CompletionItemKind.Module,
+            'class': monaco.languages.CompletionItemKind.Class,
+            'local class': monaco.languages.CompletionItemKind.Class,
+            'interface': monaco.languages.CompletionItemKind.Interface,
+            'enum': monaco.languages.CompletionItemKind.Enum,
+            'var': monaco.languages.CompletionItemKind.Variable,
+            'local var': monaco.languages.CompletionItemKind.Variable,
+            'function': monaco.languages.CompletionItemKind.Function,
+            'local function': monaco.languages.CompletionItemKind.Function,
+            'method': monaco.languages.CompletionItemKind.Method,
+            'getter': monaco.languages.CompletionItemKind.Property,
+            'setter': monaco.languages.CompletionItemKind.Method,
+            'property': monaco.languages.CompletionItemKind.Property,
+            'constructor': monaco.languages.CompletionItemKind.Constructor,
+            'construct': monaco.languages.CompletionItemKind.Constructor,
+            'label': monaco.languages.CompletionItemKind.Variable,
+            'alias': monaco.languages.CompletionItemKind.Variable,
+            'const': monaco.languages.CompletionItemKind.Variable,
+            'let': monaco.languages.CompletionItemKind.Variable,
+            'external module name': monaco.languages.CompletionItemKind.Module,
         };
         var params = this.fileLocation(model, position);
         params.prefix = '.';
@@ -827,7 +839,7 @@ define('languageservice', ['vs/editor/editor.main'], function() {
                 var result = {
                     label: comp.name,
                     kind: kindMapping[comp.kind],
-                    sortText: comp.sortText
+                    sortText: comp.sortText,
                 };
                 if (comp.replacementSpan) {
                     result.range = this.rangeToMonaco(comp.replacementSpan);
@@ -869,6 +881,6 @@ define('languageservice', ['vs/editor/editor.main'], function() {
     WsHandler.prototype.send = function(lang, msg, requiresReply) {
         console.log(msg);
         this._ws.send('2' + lang + JSON.stringify(msg));
-    }
-    return { WsHandler: WsHandler, registerLanguageService: registerLanguageService };
+    };
+    return {WsHandler: WsHandler, registerLanguageService: registerLanguageService};
 });

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,9 @@
 <script type="text/javascript">
 'use strict';
 
-function EditBook_SaveFile(path, data, ondone) {
+var EditBook = {};
+
+EditBook.saveFile = function(path, data, ondone) {
     $.post("/save/", {path: path, data:data})
      .done(ondone);
 }
@@ -20,8 +22,8 @@ $(function() {
     openWs();
 });
 
-var g_heartBeat;
-var g_editor;
+var gHeartBeat;
+var gEditor;
 
 function openWs() {
     // var url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws';
@@ -29,10 +31,10 @@ function openWs() {
 
     var ws = new WebSocket(url, ["editbook"]);
     ws.onopen = function(event) {
-        g_heartBeat = setInterval(onHeartBeat, 15*1000, ws);
+        gHeartBeat = setInterval(onHeartBeat, 15*1000, ws);
 
-        g_editor = EditBook_NewEditor($("#editorPanel"), ws)
-        g_editor.init();
+        gEditor = EditBook.newEditor($("#editorPanel"), ws)
+        gEditor.init();
     };
 
     ws.onmessage = function(event) {
@@ -40,7 +42,7 @@ function openWs() {
         switch(event.data[0]) {
         case '0':
             var opcmd = JSON.parse(data);
-            g_editor.open(opcmd.path, opcmd.data, opcmd.abspath);
+            gEditor.open(opcmd.path, opcmd.data, opcmd.abspath);
             break;
         case '1':
             // pong


### PR DESCRIPTION
This PR resolves ESlint style errors.

- suppress some rules; `no-var`, `prefer-rest-params`, and `prefer-spread` should be disabled.
- ideally, `require-jsdoc` should be enabled. It's suppressed for now.
- some automatic fixes and manual fixes