### PR TITLE
CSS / HTML refactoring.

### DIFF
--- a/editors/ace/editbook_main.js
+++ b/editors/ace/editbook_main.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function EditBook_NewEditor(div, ws) {
+EditBook.newEditor = function(ws) {
     return {
-        init: function() { initEditor(div); },
+        init: function() { initEditor(); },
         open: function(path, data) { open(path, data); }
     }
 }
@@ -28,7 +28,7 @@ function getExt(str) {
 function open(path, data) {
     console.log("editor.open called", path);
     
-    $("#pathSpan").text(path)
+    $("#path-span").text(path)
 
     var editr = ace_current;
 
@@ -49,10 +49,7 @@ function open(path, data) {
     console.log("open:" + path)
 }
 
-
-
 var ace_offsetTop = 50;
-var ace_container;
 var ace_current;
 var ace_editor;
 var ace_subeditor;
@@ -64,71 +61,39 @@ var Editor;
 var Renderer;
 
 
-function initEditor(div) {
-    var builder = [];
-    builder.push(
-'<button type="button" id="saveButton">Save</button> -- <input type="checkbox" id="split">split<br>',
-'path: <span id="pathSpan"></span><br>',
-'<div id="aceDiv" style="position:absolute;top:50;left:0;bottom:0;right:0">',
-'This is the test area.',
-'</div>'
-    );
-    div.html(builder.join(""));
-    ace_container = div;
-
-    $("#saveButton").click(function() {
-        EditBook_SaveFile($("#pathSpan").text(),
+function initEditor() {
+    $("#save-button").click(function() {
+        EditBook.saveFile($("#path-span").text(),
             ace_current.getValue(),
             function(){toastr.info("saved"); }
         );
     });
 
-    function resize(editor, top, width, height) {
-        editor.container.style.width = width + "px";
-        editor.container.style.top = top + "px";
-        editor.container.style.left = "0px";
-        editor.container.style.height = height + "px";
-        editor.resize();
-    }
-
     $("#split").change(function() {
+        var mainDiv = document.getElementById('main-div');
+        var subDiv = document.getElementById('sub-div');
         if(this.checked) {
             // split
-            ace_container.append(ace_subeditor.container);
-
-            var width = ace_editor.container.clientWidth;
-            var height = ace_editor.container.clientHeight;
-
-            var editorHeight = height / 2;
-
-            resize(ace_editor, ace_offsetTop, width, editorHeight);
-            resize(ace_subeditor, ace_offsetTop+ editorHeight, width, editorHeight);
-
+            mainDiv.style.width = '50%';
+            subDiv.style.visibility = 'visible';
 
             var session = ace_editor.session;
             session = cloneSession(session);
             ace_subeditor.setSession(session);
 
             ace_subeditor.path = ace_editor.path;
-
         } else {
             // unsplit
-
-            var width = ace_editor.container.clientWidth;
-            var height = ace_editor.container.clientHeight;
             ace_editor.setSession(ace_current.getSession());
             ace_current = ace_editor;
-
-            $(ace_subeditor.container).remove();
-            resize(ace_editor, ace_offsetTop, width, height*2);
+            subDiv.style.visibility = 'hidden';
+            mainDiv.style.width = '100%';
         }
     });
 
     // refer this folder as /editor/
     $.getScript("/editor/src-min-noconflict/ace.js", function(d, t, xhr)
     {
-
-
         ace.config.set("basePath", "/editor/src-min-noconflict");
         EditSession = ace.require("ace/edit_session").EditSession;
         UndoManager = ace.require("ace/undomanager").UndoManager;
@@ -136,29 +101,22 @@ function initEditor(div) {
         Renderer = ace.require("ace/virtual_renderer").VirtualRenderer;
         ace_lang = ace.require("ace/lib/lang");
 
-        ace_editor = ace.edit("aceDiv");
+        ace_editor = ace.edit("main-div");
         ace_current = ace_editor;
         ace_theme = "ace/theme/tomorrow_night_bright";
         ace_editor.setTheme(ace_theme);
         ace_editor.path = "";
         ace_editor.on("focus", function() {
             ace_current = ace_editor;
-            $("#pathSpan").text(ace_current.path);
+            $("#path-span").text(ace_current.path);
         });
-
-        var el = document.createElement("div");
-        el.style.cssText = "position: absolute; top:0px; bottom:0px";
-        // ace_container.appendChild(el);
-        // var session = new EditSession("");
-        ace_subeditor = new Editor(new Renderer(el, ace_theme));
+        ace_subeditor = ace.edit("sub-div");
+        ace_subeditor.setTheme(ace_theme);
         ace_subeditor.on("focus", function() {
             ace_current = ace_subeditor;
-            $("#pathSpan").text(ace_current.path);
+            $("#path-span").text(ace_current.path);
         })
     });
-
-
-
 }
 
 

--- a/editors/monaco/editbook_main.js
+++ b/editors/monaco/editbook_main.js
@@ -8,9 +8,8 @@ function notifyModifyStatusChanged() {
 }
 
 // eslint-disable-next-line no-unused-vars
-EditBook.newEditor = function(elem, ws) {
-    document.body.style.margin = '0';
-    var menu = new MonacoMenu(elem);
+EditBook.newEditor = function(ws) {
+    var menu = new MonacoMenu();
     var mainEditor = new EditBookMonacoEditor(menu.mainDiv);
     var subEditor = new EditBookMonacoEditor(menu.subDiv);
 
@@ -122,77 +121,41 @@ function notifyFocusChanged(editor) {
 // - mehu.save()
 // - menu.splitWindow = (main_div, sub_div) =>{}
 // - menu.unsplitWindow = (main_div) => {}
-function MonacoMenu(holder) {
-    var builder = [];
-    builder.push(
-'<button type="button" id="saveButton">Save</button> ' +
-'-- <input type="checkbox" id="split">split<br>',
-'path: <span id="pathSpan"></span><br>',
-'<div id="mainDiv" ' +
-'style="position:absolute;top:50;left:0;bottom:0;width:100%;overflow:hidden">',
-'</div>'
-    );
-    holder.html(builder.join(''));
-
-    var mainDiv = document.getElementById('mainDiv');
-    this.mainDiv = mainDiv;
-
-    var subDiv = document.createElement('div');
-    subDiv.style.cssText = 'position: absolute; top:0px; bottom:0px';
-    subDiv.style.overflow = 'hidden';
-    subDiv.id = 'subDiv';
-    this.subDiv = subDiv;
-
+function MonacoMenu() {
+    var mainDiv = this.mainDiv = document.getElementById('main-div');
+    var subDiv = this.subDiv = document.getElementById('sub-div');
     var menu = this;
 
-    $('#saveButton').click(function() {
+    $('#save-button').click(function() {
         menu.save();
-    }
-    );
-
-    function resize(elem, left, top, width) {
-        elem.style.width = width;
-        elem.style.top = top;
-        elem.style.left = left + 'px';
-    }
+    });
 
     $('#split').change(function() {
         // eslint-disable-next-line no-invalid-this
         if(this.checked) {
             // split
-            holder.append(subDiv);
-
-            var width = mainDiv.clientWidth;
-
-            var editorWidth = width / 2;
-
-            resize(mainDiv, 0, mainDiv.offsetTop, '50%');
-            resize(subDiv, editorWidth, mainDiv.offsetTop, '50%');
-
+            mainDiv.style.width = '50%';
+            subDiv.style.visibility = 'visible';
             menu.splitWindow(mainDiv, subDiv);
         } else {
             // unsplit
-
-            var width = mainDiv.clientWidth;
-
-            $(subDiv).remove();
-            resize(mainDiv, 0, mainDiv.top, '100%');
-
+            subDiv.style.visibility = 'hidden';
+            mainDiv.style.width = '100%';
             menu.unsplitWindow(mainDiv);
         }
     });
 }
 
 MonacoMenu.prototype.getPath = () => {
-    return $('#pathSpan').text();
+    return $('#path-span').text();
 };
 
 MonacoMenu.prototype.setPath = (path) => {
-    return $('#pathSpan').text(path);
+    return $('#path-span').text(path);
 };
 
 MonacoMenu.prototype.setEnabled = (isEnable) => {
-    $('#saveButton').prop('disabled', !isEnable);
+    $('#save-button').prop('disabled', !isEnable);
 };
 
 MonacoMenu.prototype.isSplit = () => {
@@ -212,16 +175,14 @@ EditBookMonacoEditor.prototype.registerLangServices = function(services) {
 };
 
 function getExt(str) {
-    var dot = str.lastIndexOf(".");
+    var dot = str.lastIndexOf('.');
 
     if(dot == -1)
-        return "";
+        return '';
     return str.substring(dot+1);
 }
 
-var langModeMap = {
-    "re": "markdown"
-};
+var langModeMap = {'re': 'markdown'};
 
 function lookupLanguageMode(path) {
     var ext = getExt(path);

--- a/editors/plain/editbook_main.js
+++ b/editors/plain/editbook_main.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function EditBook_NewEditor(div, ws) {
+EditBook.newEditor = function(ws) {
     return {
-        init: function() { initEditor(div); },
+        init: function() { initEditor(); },
         open: function(path, data) { open(path, data); }
     }
 }
@@ -10,25 +10,21 @@ function EditBook_NewEditor(div, ws) {
 function open(path, data) {
     console.log("editor.open called", path);
     
-    $("#pathSpan").text(path)
+    $("#path-span").text(path)
     $("#editorTextArea").val(data)
     console.log("open:" + path)
 }
 
-function initEditor(div) {
-    var builder = [];
-    builder.push(
-'<button type="button" id="saveButton">Save</button><br>',
-'path: <span id="pathSpan"></span><br>',
-'<textarea id="editorTextArea" cols="100" rows="40">',
-'This is the test area.',
-'</textarea>'
+function initEditor() {
+    $('#main-div').html(
+        '<textarea id="editor-textarea" cols="100" rows="40">' +
+        'This is the test area.' +
+        '</textarea>'
     );
-    div.html(builder.join(""));
-
-    $("#saveButton").click(function() {
-        EditBook_SaveFile($("#pathSpan").text(),
-                $("#editorTextArea").val(),
+    $('#split').prop('disabled', true);
+    $("#save-button").click(function() {
+        EditBook.saveFile($("#path-span").text(),
+                $("#editor-textarea").val(),
                 function(){alert("saved")}
                 );
     });

--- a/static/index.html
+++ b/static/index.html
@@ -33,7 +33,7 @@ function openWs() {
     ws.onopen = function(event) {
         gHeartBeat = setInterval(onHeartBeat, 15*1000, ws);
 
-        gEditor = EditBook.newEditor($("#editorPanel"), ws)
+        gEditor = EditBook.newEditor(ws)
         gEditor.init();
     };
 
@@ -64,18 +64,18 @@ function onDisconnect() {
     alert("disconnect!");
 }
 </script>
+<link rel="stylesheet" href="main.css"/>
 </head>
-<body>
+<body style="margin:0">
 
-<div id="editorPanel"></div>
-
-<!--
-<button type="button" id="saveButton">Save</button><br>
-path: <span id="pathSpan"></span><br>
-<textarea id="editorTextArea" cols="100" rows="40">
-This is the test area.
-</textarea>
--->
+<div id="menu">
+    <button type="button" id="save-button">Save</button> -- <input type="checkbox" id="split">split<br>
+    path: <span id="path-span"></span>
+</div>
+<div id="editor-panel">
+    <div id="main-div" class="editor-div" style="width:100%"></div>
+    <div id="sub-div" class="editor-div" style="left:50%;width:50%;visibility:hidden"></div>
+</div>
 
 </body>
 </html>

--- a/static/main.css
+++ b/static/main.css
@@ -1,0 +1,14 @@
+#menu {
+    height: 50px;
+}
+#editor-panel {
+    position: relative;
+    width: 100%;
+    height: calc(100% - 50px);
+}
+.editor-div {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    overflow: hidden;
+}


### PR DESCRIPTION
- move basic HTML structure to index.html. They are pretty much
  common among the editors, mostly static content.
- use CSS more to let browser layout the elements.
- introduce main.css.
- naming convention; normally HTML id/class name uses
  hyphenated words, I think.
- some bug fixes.

Question; how much do we really want to keep ace/plain editors?